### PR TITLE
Fix broken downloader: switch to pytubefix and add error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.mp4
+*.webm
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -2,20 +2,74 @@
 
 A small command-line script for downloading a YouTube video at its highest available resolution.
 
-## Why `pytubefix`?
+## Features
 
-The original script used [`pytube`](https://github.com/pytube/pytube), which is no longer actively maintained and breaks frequently as YouTube changes its player. The fix required users to manually edit `cipher.py` inside the installed library — a brittle workaround. This project now uses [`pytubefix`](https://github.com/JuanBindez/pytubefix), a maintained drop-in replacement that keeps the cipher logic up to date.
+- Downloads a single YouTube video at the highest resolution available in a progressive stream.
+- Friendly error messages instead of raw stack traces when something goes wrong.
+- No manual library patching required — uses the maintained `pytubefix` library.
 
-## Install
+## Requirements
+
+- Python 3.8 or newer
+- `pip` for installing dependencies
+
+## Installation
+
+Clone the repo and install dependencies:
 
 ```bash
+git clone https://github.com/abineshsolairaj/download_youtube_video.git
+cd download_youtube_video
+pip install -r requirements.txt
+```
+
+Using a virtual environment is recommended:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate    # on Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
 ## Usage
 
+Run the script and paste a YouTube URL when prompted:
+
 ```bash
 python downloadYoutubeVideo.py
 ```
 
-You will be prompted for a YouTube URL. The video is saved to the current working directory.
+Example session:
+
+```
+$ python downloadYoutubeVideo.py
+Enter the youtube url here: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+Downloading: Rick Astley - Never Gonna Give You Up (Official Music Video)
+Saved to: /home/you/download_youtube_video/Rick Astley - Never Gonna Give You Up (Official Music Video).mp4
+```
+
+The file is saved to the current working directory.
+
+## Why `pytubefix`?
+
+The original script used [`pytube`](https://github.com/pytube/pytube), which is no longer actively maintained and breaks frequently as YouTube changes its player. Keeping it working required users to manually edit `cipher.py` inside the installed library — a brittle workaround. This project now uses [`pytubefix`](https://github.com/JuanBindez/pytubefix), a maintained drop-in replacement that keeps the cipher logic up to date.
+
+## Troubleshooting
+
+- **`Failed to download video: ...`** — the URL was rejected by YouTube or by the library. Confirm the URL is correct, the video is public, and that your `pytubefix` is up to date (`pip install --upgrade pytubefix`).
+- **No video downloaded but no error printed** — no progressive stream was available for that video. Higher-resolution YouTube videos sometimes split video and audio into separate streams; this script intentionally sticks to a single progressive stream for simplicity.
+- **`ModuleNotFoundError: No module named 'pytubefix'`** — run `pip install -r requirements.txt` inside the right environment.
+
+## Project structure
+
+```
+.
+├── downloadYoutubeVideo.py   # entry point
+├── requirements.txt          # Python dependencies
+├── README.md                 # this file
+└── .gitignore
+```
+
+## License
+
+This project is provided as-is for educational purposes. Respect YouTube's Terms of Service and only download content you have the right to download.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,22 @@ The original script used [`pytube`](https://github.com/pytube/pytube), which is 
 - **No video downloaded but no error printed** — no progressive stream was available for that video. Higher-resolution YouTube videos sometimes split video and audio into separate streams; this script intentionally sticks to a single progressive stream for simplicity.
 - **`ModuleNotFoundError: No module named 'pytubefix'`** — run `pip install -r requirements.txt` inside the right environment.
 
+## Running the tests
+
+Unit tests use `unittest` and mock the network — no real download is required:
+
+```bash
+python -m unittest test_downloadYoutubeVideo -v
+```
+
 ## Project structure
 
 ```
 .
-├── downloadYoutubeVideo.py   # entry point
-├── requirements.txt          # Python dependencies
-├── README.md                 # this file
+├── downloadYoutubeVideo.py        # entry point
+├── test_downloadYoutubeVideo.py   # unit tests
+├── requirements.txt               # Python dependencies
+├── README.md                      # this file
 └── .gitignore
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # download_youtube_video
+
+A small command-line script for downloading a YouTube video at its highest available resolution.
+
+## Why `pytubefix`?
+
+The original script used [`pytube`](https://github.com/pytube/pytube), which is no longer actively maintained and breaks frequently as YouTube changes its player. The fix required users to manually edit `cipher.py` inside the installed library — a brittle workaround. This project now uses [`pytubefix`](https://github.com/JuanBindez/pytubefix), a maintained drop-in replacement that keeps the cipher logic up to date.
+
+## Install
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python downloadYoutubeVideo.py
+```
+
+You will be prompted for a YouTube URL. The video is saved to the current working directory.

--- a/downloadYoutubeVideo.py
+++ b/downloadYoutubeVideo.py
@@ -1,11 +1,37 @@
-import os
-from pytube import YouTube, Playlist
+from pathlib import Path
 
-youtubeURL = input("Enter the youtube url here: ")
-video = YouTube(youtubeURL)
-video.streams.get_highest_resolution().download()
+from pytubefix import YouTube
+from pytubefix.exceptions import PytubeFixError
 
 
-# Replace the lines 272, 273 with the following line in cipher.py of pytube
-# r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)',
-# r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
+def download_video(url: str, output_dir: str = ".") -> Path:
+    yt = YouTube(url)
+    stream = yt.streams.get_highest_resolution()
+    if stream is None:
+        raise RuntimeError("No downloadable stream found for this video.")
+
+    print(f"Downloading: {yt.title}")
+    file_path = stream.download(output_path=output_dir)
+    return Path(file_path)
+
+
+def main() -> None:
+    url = input("Enter the youtube url here: ").strip()
+    if not url:
+        print("No URL provided. Exiting.")
+        return
+
+    try:
+        path = download_video(url)
+    except PytubeFixError as exc:
+        print(f"Failed to download video: {exc}")
+        return
+    except Exception as exc:
+        print(f"Unexpected error: {exc}")
+        return
+
+    print(f"Saved to: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pytubefix>=6.0

--- a/test_downloadYoutubeVideo.py
+++ b/test_downloadYoutubeVideo.py
@@ -1,0 +1,88 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pytubefix.exceptions import PytubeFixError, VideoUnavailable
+
+import downloadYoutubeVideo as dl
+
+
+class DownloadVideoTests(unittest.TestCase):
+    @patch("downloadYoutubeVideo.YouTube")
+    def test_returns_downloaded_path(self, mock_yt_cls):
+        stream = MagicMock()
+        stream.download.return_value = "/tmp/video.mp4"
+        yt = MagicMock(title="Test Title")
+        yt.streams.get_highest_resolution.return_value = stream
+        mock_yt_cls.return_value = yt
+
+        result = dl.download_video("https://example.test/v", output_dir="/tmp")
+
+        mock_yt_cls.assert_called_once_with("https://example.test/v")
+        stream.download.assert_called_once_with(output_path="/tmp")
+        self.assertEqual(result, Path("/tmp/video.mp4"))
+
+    @patch("downloadYoutubeVideo.YouTube")
+    def test_raises_when_no_stream_available(self, mock_yt_cls):
+        yt = MagicMock(title="No Streams")
+        yt.streams.get_highest_resolution.return_value = None
+        mock_yt_cls.return_value = yt
+
+        with self.assertRaises(RuntimeError) as ctx:
+            dl.download_video("https://example.test/v")
+        self.assertIn("No downloadable stream", str(ctx.exception))
+
+    @patch("downloadYoutubeVideo.YouTube")
+    def test_propagates_pytubefix_error(self, mock_yt_cls):
+        mock_yt_cls.side_effect = VideoUnavailable("xyz")
+        with self.assertRaises(PytubeFixError):
+            dl.download_video("https://example.test/v")
+
+
+class MainCliTests(unittest.TestCase):
+    def _run_main(self, fake_input):
+        captured = io.StringIO()
+        with patch("builtins.input", return_value=fake_input), \
+             patch("sys.stdout", new=captured):
+            dl.main()
+        return captured.getvalue()
+
+    def test_empty_input_exits_cleanly(self):
+        output = self._run_main("")
+        self.assertIn("No URL provided", output)
+
+    @patch("downloadYoutubeVideo.download_video")
+    def test_success_prints_saved_path(self, mock_download):
+        mock_download.return_value = Path("/tmp/video.mp4")
+        captured = io.StringIO()
+        with patch("builtins.input", return_value="https://example.test/v"), \
+             patch("sys.stdout", new=captured):
+            dl.main()
+        self.assertIn("Saved to: /tmp/video.mp4", captured.getvalue())
+
+    @patch("downloadYoutubeVideo.download_video")
+    def test_pytubefix_error_prints_friendly_message(self, mock_download):
+        mock_download.side_effect = VideoUnavailable("xyz")
+        captured = io.StringIO()
+        with patch("builtins.input", return_value="https://example.test/v"), \
+             patch("sys.stdout", new=captured):
+            dl.main()
+        out = captured.getvalue()
+        self.assertIn("Failed to download video", out)
+        self.assertNotIn("Traceback", out)
+
+    @patch("downloadYoutubeVideo.download_video")
+    def test_unexpected_error_is_caught(self, mock_download):
+        mock_download.side_effect = RuntimeError("boom")
+        captured = io.StringIO()
+        with patch("builtins.input", return_value="https://example.test/v"), \
+             patch("sys.stdout", new=captured):
+            dl.main()
+        out = captured.getvalue()
+        self.assertIn("Unexpected error: boom", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Audited the small downloader script and found several issues; this PR addresses them.

### Problems with the original script
- **Unused imports** (`os`, `Playlist`) were carried for no reason.
- **No error handling** — invalid URLs, network failures, or unavailable videos crashed with raw tracebacks.
- **`pytube` is unmaintained.** The repo's own comments told users to manually patch `cipher.py` inside the installed library to keep it working. That hack rots quickly and is hostile to anyone trying the script for the first time.
- **No user feedback** — no indication of progress, success, or where the file was saved.
- **No `if __name__ == "__main__"` guard.**
- **No `requirements.txt`**, and the README contained only the project name.

### Changes
- Replaced `pytube` with [`pytubefix`](https://github.com/JuanBindez/pytubefix), a maintained drop-in replacement that handles YouTube's cipher changes automatically — removing the need for the manual `cipher.py` patch.
- Extracted `download_video()` and `main()` functions and added a `__main__` guard.
- Added graceful error handling for `PytubeFixError` and unexpected exceptions, with user-readable messages.
- Print the video title before download and the saved path after.
- Removed unused imports.
- Added `requirements.txt`, `.gitignore`, and usage instructions in the README.

## Test plan
- [x] `python -m py_compile downloadYoutubeVideo.py` passes
- [ ] `pip install -r requirements.txt && python downloadYoutubeVideo.py` with a real YouTube URL downloads the video and prints the saved path
- [ ] Running with an empty input exits cleanly with `No URL provided.`
- [ ] Running with an invalid URL prints a `Failed to download video:` message instead of a traceback


---
_Generated by [Claude Code](https://claude.ai/code/session_01SCM8aSFPgN21oMhTK7pfJk)_